### PR TITLE
feature(handler): manage generator try/catch

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,15 +125,40 @@ And same as for **IO**, don't use **.run()** everywhere in your codebase.
 
 **handlers** are combinable together : **you can yield a handler**.
 
-## Asynchronous code
+### Deal with errors
+You can throw an error inside IO or Handler.
+
+Errors can be try/catch 3 ways :
+- try/catch [io .run()](#run-io) method.
+- try/catch [handler .run()](#run-handlers) method.
+- try/catch inside handler.
+
+e.g.
+
+```js
+const handler1 = handler(function*() {
+  throw new Error();
+});
+
+const io1 = io(() => { throw new Error() });
+
+// handler2 is safe, it can't throw because it handlers errors
+const handler2 = handler(function*() {
+  try {
+    yield io1();
+    yield handler1();
+  } catch (e) {
+    console.error(e);
+  }
+});
+
+```
+
+### Asynchronous code
 
 *[WIP]*
 
-## Errors
-
-*[WIP]*
-
-## API
+### API
 
 *[WIP]*
 

--- a/__bundle_tests__/errors.js
+++ b/__bundle_tests__/errors.js
@@ -1,0 +1,152 @@
+import expect from 'expect.js';
+import { test, describe } from 'async-describe';
+
+module.exports = ({ io, handler, testHandler }) => (
+  describe('errors', async () => {
+    const isError = e => { expect(e).to.match(/\[error\]/) }
+    const makeError = io(() => { throw new Error('[error]') });
+
+    await describe('failed io', async () => {
+      await test('run io', async () => {
+        expect(makeError().run).to.throwError(isError);
+      });
+    });
+
+    await describe('failed handler', async () => {
+      const failedHandler = handler(function*() { throw new Error('[error]') });
+
+      await test('run handler', async () => {
+        expect(failedHandler().run).to.throwError(isError);
+      });
+
+      await test('run testHandler (failure)', async () => {
+        expect(testHandler(failedHandler()).run).to.throwError(isError);
+      });
+    });
+
+    await describe('failed handler (via failed io)', async () => {
+      const failedHandler = handler(function*() {
+        yield makeError();
+        return 42;
+      });
+
+      await test('run handler', async () => {
+        expect(failedHandler().run).to.throwError(isError);
+      });
+
+      await test('run testHandler (success)', async () => {
+        testHandler(failedHandler())
+          .matchIo(makeError())
+          .shouldReturn(42)
+          .run()
+      });
+
+      await test('run testHandler (failure)', async () => {
+        expect(testHandler(failedHandler())
+          .matchIo(makeError(1, 2, 3))
+          .shouldReturn(42)
+          .run
+        ).to.throwError(e => {
+          expect(e).to.match(/Invalid IO#0 function arguments/)
+        })
+      });
+    });
+
+    await describe('handler that catch failed io', async () => {
+      const safeHandler = handler(function*() {
+        try {
+          yield makeError();
+        } catch (e) {
+          return 42;
+        }
+        return 'no error';
+      });
+
+      await test('run handler', async () => {
+        expect(safeHandler().run()).to.be(42);
+      });
+
+      await test('run testHandler (success)', async () => {
+        testHandler(safeHandler())
+          .matchIo(makeError())
+          .shouldReturn('no error')
+          .run()
+      });
+
+      await test('run testHandler (failure)', async () => {
+        expect(testHandler(safeHandler())
+          .matchIo(makeError(1, 2, 3))
+          .shouldReturn('no error')
+          .run
+        ).to.throwError(e => {
+          expect(e).to.match(/Invalid IO#0 function arguments/)
+        })
+      });
+    });
+
+    await describe('failed handler (via other failed handler)', async () => {
+      const failedHandler = handler(function*() {
+        return yield (handler(function*() {
+          yield makeError();
+          return 42;
+        }))();
+      });
+
+      await test('run handler', async () => {
+        expect(failedHandler().run).to.throwError(isError);
+      });
+
+      await test('run testHandler (success)', async () => {
+        testHandler(failedHandler())
+          .matchIo(makeError())
+          .shouldReturn(42)
+          .run()
+      });
+
+      await test('run testHandler (failure)', async () => {
+        expect(testHandler(failedHandler())
+          .matchIo(makeError(1, 2, 3))
+          .shouldReturn(42)
+          .run
+        ).to.throwError(e => {
+          expect(e).to.match(/Invalid IO#0 function arguments/)
+        })
+      });
+    });
+
+    await describe('handler that catch another failed handler', async () => {
+      const failedHandler = handler(function*() {
+        return yield makeError();
+      })
+      const safeHandler = handler(function*() {
+        try {
+          yield failedHandler()
+        } catch (e) {
+          return 42;
+        }
+        return 'no error';
+      });
+
+      await test('run handler', async () => {
+        expect(safeHandler().run()).to.be(42);
+      });
+
+      await test('run testHandler (success)', async () => {
+        testHandler(safeHandler())
+          .matchIo(makeError())
+          .shouldReturn('no error')
+          .run()
+      });
+
+      await test('run testHandler (failure)', async () => {
+        expect(testHandler(safeHandler())
+          .matchIo(makeError(1, 2, 3))
+          .shouldReturn('no error')
+          .run
+        ).to.throwError(e => {
+          expect(e).to.match(/Invalid IO#0 function arguments/)
+        })
+      });
+    });
+  })
+)

--- a/__bundle_tests__/index.js
+++ b/__bundle_tests__/index.js
@@ -8,6 +8,7 @@ import rollupConfigs from '../rollup.config.js';
 
 const testSuites = [
   require('./api'),
+  require('./errors'),
   require('./example-readme-logtwice'),
   require('./example-readme-addvalues'),
 ];

--- a/__tests__/internal/BypassHandlerError.js
+++ b/__tests__/internal/BypassHandlerError.js
@@ -1,0 +1,17 @@
+import BypassHandlerError from '../../src/internal/BypassHandlerError';
+
+describe('handle-io/internal/BypassHandlerError', () => {
+  describe('instanceof', () => {
+    test('is instance of BypassHandlerError', () => {
+      expect(new BypassHandlerError()).toBeInstanceOf(BypassHandlerError);
+    });
+
+    test('is not instance of Error', () => {
+      expect(new BypassHandlerError()).not.toBeInstanceOf(Error);
+    });
+
+    test('access to original Error', () => {
+      expect(new BypassHandlerError().e).toBeInstanceOf(Error);
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "test:coverage": "npm run test -- --coverage",
     "test:update": "npm run test -- --updateSnapshot",
     "test:bundle": "NODE_ENV=test node -r babel-register -r babel-polyfill __bundle_tests__/index.js",
+    "test:bundle:watch": "NODE_ENV=test nodemon -i __bundle_tests__/tmp -r babel-register -r babel-polyfill __bundle_tests__/index.js",
     "test:nsp": "nsp check",
     "test:all": "npm run lint && npm run test && npm run test:bundle",
     "lint": "eslint .",

--- a/src/handler.js
+++ b/src/handler.js
@@ -1,4 +1,5 @@
 import ioRunner from './internal/ioRunner';
+import BypassHandlerError from './internal/BypassHandlerError';
 
 const noopGen = function*() {}
 
@@ -10,7 +11,14 @@ const createHandler = (ioGen = noopGen, args) => {
       let genResult = gen.next()
       while (!genResult.done) {
         const { value: io } = genResult
-        genResult = gen.next(io.run(runner))
+        try {
+          genResult = gen.next(io.run(runner))
+        } catch (e) {
+          if (e instanceof BypassHandlerError) {
+            throw e
+          }
+          genResult = gen.throw(e)
+        }
       }
       return genResult.value
     }

--- a/src/internal/BypassHandlerError.js
+++ b/src/internal/BypassHandlerError.js
@@ -1,0 +1,9 @@
+const BypassHandlerError = function(...args) {
+  this.e = new Error(...args);
+}
+
+BypassHandlerError.prototype.toString = function() {
+  return `${this.constructor.name}: ${this.e.message}`;
+}
+
+export default BypassHandlerError;

--- a/src/testHandler.js
+++ b/src/testHandler.js
@@ -1,3 +1,4 @@
+import BypassHandlerError from './internal/BypassHandlerError';
 import isEqual from 'lodash.isequal';
 import { stringify } from './internal/utils';
 
@@ -18,16 +19,16 @@ const createTestHandler = (h, mockedIOs = [], expectedRetValue, assertRet = fals
       let mockIndex = 0;
       const retValue = h.run((io) => {
         if (!mockedIOs[mockIndex]) {
-          throw new Error('Too much runned io')
+          throw new BypassHandlerError('Too much runned io')
         }
         const [expectedIO, mockedRetValue] = mockedIOs[mockIndex];
         if (!isEqual(io.f, expectedIO.f)) {
-          throw new Error(`Invalid IO#${mockIndex} function`)
+          throw new BypassHandlerError(`Invalid IO#${mockIndex} function`)
         }
         if (!isEqual(io.args, expectedIO.args)) {
           const expectedArgs = stringify(expectedIO.args);
           const ioArgs = stringify(io.args);
-          throw new Error(`Invalid IO#${mockIndex} function arguments: expected \n${expectedArgs}\nbut got \n${ioArgs}`)
+          throw new BypassHandlerError(`Invalid IO#${mockIndex} function arguments: expected \n${expectedArgs}\nbut got \n${ioArgs}`)
         }
         mockIndex += 1;
         return mockedRetValue;


### PR DESCRIPTION
- src: add handler try/catch (+ unit tests)
- src: add internal/BypassHandlerError (+ unit tests)
- src: handler re-throw catched BypassHandlerError
- src: estHandler now throws ByPassHandlerError in test runner
- test: add __bundle_tests__/errors.js
- chore(npm): add test:bundle:watch script
- doc: write "Deal with errors" section in README

Closes #34