### PR TITLE
feat(handler): promises support

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,27 +128,62 @@ And same as for **IO**, don't use **.run()** everywhere in your codebase.
 
 **handlers** are combinable together : **you can yield a handler**.
 
+### Promise support
+
+`handle-io` support promises and allow you to create asynchronous IO.
+
+**e.g.**
+```js
+// async io
+const sleep = io((ms) => new Promise(resolve => setTimeout(resolve, ms)));
+
+// create an async combination
+const sleepSecond = handler(function*(s) {
+  yield sleep(s * 1000);
+  return s;
+});
+
+// test this combination synchronously
+testHander(sleepSecond(42))
+  .matchIo(sleep(42000))
+  .shouldReturn(42)
+  .run()
+```
+
+Please note `sleep(n)` and `sleepSecond(n)` will expose .run() method that return a promise.
+
+**e.g.**
+```js
+sleepSecond(1).run().then((n) => {
+  console.log(`${n} second(s) waited`);
+})
+```
+
 ### Deal with errors
-You can throw an error inside IO or Handler.
+The very simple way to handle errors with `handle-io` is to use try/catch blocks.
 
-Errors can be try/catch 3 ways :
-- try/catch [io .run()](#run-io) method.
-- try/catch [handler .run()](#run-handlers) method.
-- try/catch inside handler.
+As you can see in the example below, you can try/catch any errors inside a handler :
+- Synchronous error (throw) from io
+- Asynchronous error (unhandled promise rejection) from io
+- Throw from another handler
 
-e.g.
-
+**e.g.**
 ```js
 const handler1 = handler(function*() {
   throw new Error();
 });
 
+// Synchronous IO
 const io1 = io(() => { throw new Error() });
+
+// Asynchronous IO
+const io2 = io(() => Promise.reject(new Error()));
 
 // handler2 is safe, it can't throw because it handles errors
 const handler2 = handler(function*() {
   try {
     yield io1();
+    yield io2();
     yield handler1();
   } catch (e) {
     console.error(e);
@@ -156,15 +191,6 @@ const handler2 = handler(function*() {
 });
 
 ```
-
-### Asynchronous code
-
-*[WIP]*
-
-### API
-
-*[WIP]*
-
 
 ## License
 [MIT](https://github.com/guillaumearm/handle-io/blob/master/LICENSE)

--- a/__bundle_tests__/example-readme-errors.js
+++ b/__bundle_tests__/example-readme-errors.js
@@ -1,0 +1,37 @@
+import expect from 'expect.js';
+import { test, describe } from 'async-describe';
+
+module.exports = ({ io, handler }) => (
+  describe('[README.md] Deal with errors', async () => {
+    const handlerError = handler(function*() {
+      throw '1';
+    });
+
+    // Synchronous IO
+    const syncIoError = io(() => { throw '2' });
+
+    // Asynchronous IO
+    const asyncIoError = io(() => Promise.reject('3'));
+
+    const catchError = handler(function*(yieldable) {
+      try {
+        yield yieldable
+      } catch (e) {
+        return e;
+      }
+    });
+
+    await test('catch handler errors', () => {
+      expect(catchError(handlerError()).run()).to.be('1');
+    })
+
+    await test('catch synchronous io errors', () => {
+      expect(catchError(syncIoError()).run()).to.be('2');
+    })
+
+    await test('catch asynchronous io errors', async () => {
+      const result = await catchError(asyncIoError()).run();
+      expect(result).to.be('3');
+    })
+  })
+)

--- a/__bundle_tests__/example-readme-promises.js
+++ b/__bundle_tests__/example-readme-promises.js
@@ -1,0 +1,41 @@
+import sinon from 'sinon';
+import expect from 'expect.js';
+import { test, describe } from 'async-describe';
+
+module.exports = ({ io, handler, testHandler }) => (
+  describe('[README.md] Promises support', async () => {
+    // here, setTimeout from example is replaced by a spy
+    const fakeSetTimeout = sinon.spy();
+
+    // async io
+    const sleep = io((ms) => new Promise(resolve => {
+      fakeSetTimeout(ms);
+      resolve();
+    }));
+
+    // create an async combination
+    const sleepSecond = handler(function*(s) {
+      yield sleep(s * 1000);
+      return s;
+    });
+
+    await test('runs sleep(1000)', async () => {
+      fakeSetTimeout.resetHistory()
+      await sleep(1000).run()
+      expect(fakeSetTimeout.calledWithExactly(1000)).to.be.ok();
+    })
+
+    await test('runs sleepSecond(2) gives no error', async () => {
+      fakeSetTimeout.resetHistory()
+      await sleepSecond(2).run();
+      expect(fakeSetTimeout.calledWithExactly(2000)).to.be.ok();
+    })
+
+    await test('logs sleep 42 seconds', () => {
+      testHandler(sleepSecond(42))
+        .matchIo(sleep(42000))
+        .shouldReturn(42)
+        .run()
+    })
+  })
+)

--- a/__bundle_tests__/index.js
+++ b/__bundle_tests__/index.js
@@ -8,9 +8,11 @@ import rollupConfigs from '../rollup.config.js';
 
 const testSuites = [
   require('./api'),
-  require('./errors'),
+  require('./sync-errors'),
   require('./example-readme-logtwice'),
   require('./example-readme-addvalues'),
+  require('./example-readme-promises'),
+  require('./example-readme-errors'),
 ];
 
 const bundlePrefix = 'bundle-'

--- a/__bundle_tests__/sync-errors.js
+++ b/__bundle_tests__/sync-errors.js
@@ -2,7 +2,7 @@ import expect from 'expect.js';
 import { test, describe } from 'async-describe';
 
 module.exports = ({ io, handler, testHandler }) => (
-  describe('errors', async () => {
+  describe('synchronous errors', async () => {
     const isError = e => { expect(e).to.match(/\[error\]/) }
     const makeError = io(() => { throw new Error('[error]') });
 

--- a/__tests__/handler.js
+++ b/__tests__/handler.js
@@ -13,170 +13,253 @@ describe('handle-io/handler', () => {
   });
 
   describe('handler instances', () => {
-    describe('default handler (noop)', () => {
-      const defaultHandler = handler();
-      test('is a function', () => {
-        expect(typeof defaultHandler).toBe('function');
-      });
-      test('has no "run" method', () => {
-        expect(defaultHandler.run).toBe(undefined);
-      })
-      test('calls run returns undefined', () => {
-        expect(defaultHandler().run()).toBe(undefined);
-      })
-      test('calls run returns undefined when applied several times', () => {
-        expect(defaultHandler()()().run()).toBe(undefined);
-      })
-    });
-
-    describe('handler that takes several arguments and returns a value', () => {
-      const listHandler = handler(function*(...args) {
-        return args;
-      });
-      test('is a function', () => {
-        expect(typeof listHandler).toBe('function');
-      });
-      test('has no "run" method', () => {
-        expect(listHandler.run).toBe(undefined);
-      })
-      test('calls run returns [1, 2, 3]', () => {
-        expect(listHandler(1, 2, 3).run()).toEqual([1, 2, 3]);
-      })
-      test('calls run returns [1, 2, 3] when applied several times', () => {
-        expect(listHandler(0)(42)(1, 2, 3).run()).toEqual([1, 2, 3]);
-      })
-    });
-
-    describe('handler with custom runner', () => {
-      const mockedHandler = handler(function* (arg) {
-        const a = yield { run: applyTo(arg) };
-        const b = yield { run: applyTo(a) };
-        const c = yield { run: applyTo(b) };
-        return [arg, a, b ,c];
-      });
-      test('mockedHandler(42) returns [42, 43, 44, 45]', () => {
-        expect(mockedHandler(42).run(inc)).toEqual([42, 43, 44, 45]);
-      });
-      test('mockedHandler(42) runs the runner 3 times', () => {
-        const runner = jest.fn(inc);
-        mockedHandler(42).run(runner);
-        expect(runner.mock.calls).toHaveLength(3);
-        expect(runner.mock.calls).toEqual([[42], [43], [44]])
-      });
-    });
-
-    describe('handler with default runner', () => {
-      const createMockedHandler = f => handler(function* (arg) {
-        const a = yield { run: applyTo({ f, args: [arg] }) };
-        const b = yield { run: applyTo({ f, args: [a] }) };
-        const c = yield { run: applyTo({ f, args: [b] }) };
-        return [arg, a, b ,c];
+    describe('synchronous', () => {
+      describe('default handler (noop)', () => {
+        const defaultHandler = handler();
+        test('is a function', () => {
+          expect(typeof defaultHandler).toBe('function');
+        });
+        test('has no "run" method', () => {
+          expect(defaultHandler.run).toBe(undefined);
+        })
+        test('calls run returns undefined', () => {
+          expect(defaultHandler().run()).toBe(undefined);
+        })
+        test('calls run returns undefined when applied several times', () => {
+          expect(defaultHandler()()().run()).toBe(undefined);
+        })
       });
 
-      test('mockedHandler(42) returns [42, 43, 44, 45]', () => {
-        const mockedHandler = createMockedHandler(inc);
-        expect(mockedHandler(42).run()).toEqual([42, 43, 44, 45]);
+      describe('handler that takes several arguments and returns a value', () => {
+        const listHandler = handler(function*(...args) {
+          return args;
+        });
+        test('is a function', () => {
+          expect(typeof listHandler).toBe('function');
+        });
+        test('has no "run" method', () => {
+          expect(listHandler.run).toBe(undefined);
+        })
+        test('calls run returns [1, 2, 3]', () => {
+          expect(listHandler(1, 2, 3).run()).toEqual([1, 2, 3]);
+        })
+        test('calls run returns [1, 2, 3] when applied several times', () => {
+          expect(listHandler(0)(42)(1, 2, 3).run()).toEqual([1, 2, 3]);
+        })
       });
 
-      test('mockedHandler(42) runs the runner 3 times', () => {
-        const runner = jest.fn(inc);
-        const mockedHandler = createMockedHandler(runner);
-        mockedHandler(42).run();
-        expect(runner.mock.calls).toHaveLength(3);
-        expect(runner.mock.calls).toEqual([[42], [43], [44]])
+      describe('handler with custom runner', () => {
+        const mockedHandler = handler(function* (arg) {
+          const a = yield { run: applyTo(arg) };
+          const b = yield { run: applyTo(a) };
+          const c = yield { run: applyTo(b) };
+          return [arg, a, b ,c];
+        });
+        test('mockedHandler(42) returns [42, 43, 44, 45]', () => {
+          expect(mockedHandler(42).run(inc)).toEqual([42, 43, 44, 45]);
+        });
+        test('mockedHandler(42) runs the runner 3 times', () => {
+          const runner = jest.fn(inc);
+          mockedHandler(42).run(runner);
+          expect(runner.mock.calls).toHaveLength(3);
+          expect(runner.mock.calls).toEqual([[42], [43], [44]])
+        });
       });
-    });
 
-    describe('nested handlers (with custom runner)', () => {
-      const simpleHandler = handler(function* (arg) {
-        const a = yield { run: applyTo(arg) };
-        const b = yield { run: applyTo(arg) };
-        return [a, b];
-      });
-      const composedHandler = handler(function* (arg) {
-        const [a, b] = yield simpleHandler(arg);
-        const [c, d] = yield simpleHandler(arg);
-        return [a, b, c, d];
-      });
-      test('composedHandler(42) returns [42, 42, 42, 42]', () => {
-        expect(composedHandler(42).run(identity)).toEqual([42, 42, 42, 42]);
-      });
-      test('composedHandler(42) runs the runner 4 times', () => {
-        const runner = jest.fn(identity);
-        composedHandler(42).run(runner);
-        expect(runner.mock.calls).toHaveLength(4);
-        expect(runner.mock.calls).toEqual([[42], [42], [42], [42]])
-      });
-    });
+      describe('handler with default runner', () => {
+        const createMockedHandler = f => handler(function* (arg) {
+          const a = yield { run: applyTo({ f, args: [arg] }) };
+          const b = yield { run: applyTo({ f, args: [a] }) };
+          const c = yield { run: applyTo({ f, args: [b] }) };
+          return [arg, a, b ,c];
+        });
 
-    describe('handler that throws Error', () => {
-      const handlerWithError = handler(function* () {
-        throw new Error('[error]');
-      })
-      test('throws an error', () => {
-        expect(handlerWithError().run).toThrow('[error]');
-      })
-    });
+        test('mockedHandler(42) returns [42, 43, 44, 45]', () => {
+          const mockedHandler = createMockedHandler(inc);
+          expect(mockedHandler(42).run()).toEqual([42, 43, 44, 45]);
+        });
 
-    describe('nested handler that throws Error', () => {
-      const handlerWithError = handler(function* () {
-        yield handler(function* () {
+        test('mockedHandler(42) runs the runner 3 times', () => {
+          const runner = jest.fn(inc);
+          const mockedHandler = createMockedHandler(runner);
+          mockedHandler(42).run();
+          expect(runner.mock.calls).toHaveLength(3);
+          expect(runner.mock.calls).toEqual([[42], [43], [44]])
+        });
+      });
+
+      describe('nested handlers (with custom runner)', () => {
+        const simpleHandler = handler(function* (arg) {
+          const a = yield { run: applyTo(arg) };
+          const b = yield { run: applyTo(arg) };
+          return [a, b];
+        });
+        const composedHandler = handler(function* (arg) {
+          const [a, b] = yield simpleHandler(arg);
+          const [c, d] = yield simpleHandler(arg);
+          return [a, b, c, d];
+        });
+        test('composedHandler(42) returns [42, 42, 42, 42]', () => {
+          expect(composedHandler(42).run(identity)).toEqual([42, 42, 42, 42]);
+        });
+        test('composedHandler(42) runs the runner 4 times', () => {
+          const runner = jest.fn(identity);
+          composedHandler(42).run(runner);
+          expect(runner.mock.calls).toHaveLength(4);
+          expect(runner.mock.calls).toEqual([[42], [42], [42], [42]])
+        });
+      });
+
+      describe('handler that throws Error', () => {
+        const handlerWithError = handler(function* () {
           throw new Error('[error]');
-        })()
-      })
-      test('throws an error', () => {
-        expect(handlerWithError().run).toThrow('[error]');
-      })
-    });
+        })
+        test('throws an error', () => {
+          expect(handlerWithError().run).toThrow('[error]');
+        })
+      });
 
-    describe('nested handler that throws Error (catched)', () => {
-      const handlerWithError = handler(function* () {
-        try {
+      describe('nested handler that throws Error', () => {
+        const handlerWithError = handler(function* () {
           yield handler(function* () {
             throw new Error('[error]');
           })()
-        } catch (e) {
-          return 'no error'
-        }
-      })
-      test('throws an error', () => {
-        expect(handlerWithError().run()).toBe('no error');
-      })
-    });
+        })
+        test('throws an error', () => {
+          expect(handlerWithError().run).toThrow('[error]');
+        })
+      });
 
-    describe('handler that throws BypassHandlerError', () => {
-      const handlerWithError = handler(function* () {
-        throw new BypassHandlerError('[error]');
-      })
-      test('throws an error', () => {
-        expect(handlerWithError().run).toThrow('[error]');
-      })
-    });
+      describe('nested handler that throws Error (catched)', () => {
+        const handlerWithError = handler(function* () {
+          try {
+            yield handler(function* () {
+              throw new Error('[error]');
+            })()
+          } catch (e) {
+            return 'no error'
+          }
+        })
+        test('throws an error', () => {
+          expect(handlerWithError().run()).toBe('no error');
+        })
+      });
 
-    describe('nested handlers that throws BypassHandlerError', () => {
-      const handleWithError = handler(function* () {
-        yield handler(function* () {
+      describe('handler that throws BypassHandlerError', () => {
+        const handlerWithError = handler(function* () {
           throw new BypassHandlerError('[error]');
-        })()
-      })
-      test('throws an error', () => {
-        expect(handleWithError().run).toThrow('[error]');
-      })
-    });
+        })
+        test('throws an error', () => {
+          expect(handlerWithError().run).toThrow('[error]');
+        })
+      });
 
-    describe('nested handlers that throws BypassHandlerError (cannot be catched)', () => {
-      const handleWithError = handler(function* () {
-        try {
+      describe('nested handlers that throws BypassHandlerError', () => {
+        const handleWithError = handler(function* () {
           yield handler(function* () {
             throw new BypassHandlerError('[error]');
           })()
-        } catch (e) {
-          return 'no error'
-        }
-      })
-      test('throws an error', () => {
-        expect(handleWithError().run).toThrow('[error]');
-      })
+        })
+        test('throws an error', () => {
+          expect(handleWithError().run).toThrow('[error]');
+        })
+      });
+
+      describe('nested handlers that throws BypassHandlerError (cannot be catched)', () => {
+        const handleWithError = handler(function* () {
+          try {
+            yield handler(function* () {
+              throw new BypassHandlerError('[error]');
+            })()
+          } catch (e) {
+            return 'no error'
+          }
+        })
+        test('throws an error', () => {
+          expect(handleWithError().run).toThrow('[error]');
+        })
+      });
+    });
+
+    describe('asynchronous handlers', () => {
+      test('one async operation', async () => {
+        const asyncHandler = handler(function*() {
+          return yield { run: applyTo({ f: async x => x, args: [42] }) };
+        });
+        const result = await asyncHandler().run();
+        expect(result).toBe(42);
+      });
+
+      test('several async operations', () => {
+        const asyncHandler = handler(function*() {
+          const a = yield { run: applyTo({ f: async x => x, args: [20] }) };
+          const b = yield { run: applyTo({ f: async x => x, args: [20] }) };
+          const c = yield { run: applyTo({ f: async x => x, args: [2] }) };
+          return a + b + c
+        });
+        return expect(asyncHandler().run()).resolves.toBe(42);
+      });
+
+      test('mixed synchronous and asynchronous operations', () => {
+        const asyncHandler = handler(function*() {
+          const a = yield { run: applyTo({ f: async x => x, args: [10] }) };
+          const b = yield { run: applyTo({ f: x => x, args: [10] }) };
+          const c = yield { run: applyTo({ f: async x => x, args: [10] }) };
+          const d = yield { run: applyTo({ f: x => x, args: [10] }) };
+          const e = yield { run: applyTo({ f: async x => x, args: [2] }) };
+          return a + b + c + d + e;
+        });
+        return expect(asyncHandler().run()).resolves.toBe(42);
+      });
+
+      test('mixed synchronous and asynchronous operations (nested)', () => {
+        const asyncHandler = handler(function*() {
+          return yield handler(function*() {
+            const a = yield { run: applyTo({ f: async x => x, args: [10] }) };
+            const b = yield { run: applyTo({ f: x => x, args: [10] }) };
+            const c = yield { run: applyTo({ f: async x => x, args: [10] }) };
+            const d = yield { run: applyTo({ f: x => x, args: [10] }) };
+            const e = yield { run: applyTo({ f: async x => x, args: [2] }) };
+            return a + b + c + d + e;
+          })();
+        });
+        return expect(asyncHandler().run()).resolves.toBe(42);
+      });
+
+      test('rejected async operation', () => {
+        const asyncHandler = handler(function*() {
+          return yield { run: applyTo({ f: () => Promise.reject('rejected !'), args: [] }) }
+        });
+        return expect(asyncHandler().run()).rejects.toBe('rejected !')
+      });
+
+      test('rejected and catched async operation', () => {
+        const asyncHandler = handler(function*() {
+          let res, err;
+          try {
+            res = yield { run: applyTo({ f: () => Promise.reject('rejected !'), args: [] }) }
+          } catch (e) {
+            err = e
+          }
+          return [res, err];
+        });
+        return expect(asyncHandler().run()).resolves.toEqual([undefined, 'rejected !'])
+      });
+
+      test('rejected and catched async operation (nested)', () => {
+        const asyncHandler = handler(function*() {
+          return yield handler(function*() {
+            let res, err;
+            try {
+              res = yield { run: applyTo({ f: () => Promise.reject('rejected !'), args: [] }) }
+            } catch (e) {
+              err = e
+            }
+            return [res, err];
+          })();
+        });
+        return expect(asyncHandler().run()).resolves.toEqual([undefined, 'rejected !'])
+      });
     });
   });
 });


### PR DESCRIPTION
- rewrite handler .run() method (recursive way)
- handler support promises
- rewrite "Deal with errors" part in README
- write "Promise Support" part in README
- rename "errors.js" in "sync-errors.js" (__bundle_tests__)
- write "example-readme-promises.js" (__bundle_tests__)
- write "example-readme-errors.js" (__bundle_tests__)

Closes #35